### PR TITLE
Remove reference to apache2_sites_html in README and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ These can be included into your site definitions.
           - { name: foobar, password: foobar }
     openssl_self_signed:
       - { name: 'foobar.local', country: 'DE', state: 'Bavaria', city: 'Munich', organization: 'Foo Bar', email: 'foo@bar.com' }
-    apache2_sites_html:
+    apache2_sites:
       - id: foobar
         state: present
         name: foobar.local

--- a/test.yml
+++ b/test.yml
@@ -15,7 +15,7 @@
           - { name: foobar, password: foobar }
     openssl_self_signed:
       - { name: 'foobar.local', country: 'DE', state: 'Bavaria', city: 'Munich', organization: 'Foo Bar', email: 'foo@bar.com' }
-    apache2_sites_html:
+    apache2_sites:
       - id: foobar
         state: present
         name: foobar.local


### PR DESCRIPTION
apache2_sites_html doesn't appear anywhere else in the codebase so I assume it is
meant to be apache2_sites.
