### PR TITLE
Clarify readme rules section

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ These are the handlers that are defined in `handlers/main.yml`.
 
 ## Rules
 
-In addition some configuration rules will be copied unconditionally to `/etc/apache2/rules`:
+Some configuration fragments will be copied unconditionally to `/etc/apache2/rules`:
 
 * compression.conf
 * cors_ajax.conf
@@ -146,7 +146,7 @@ In addition some configuration rules will be copied unconditionally to `/etc/apa
 * ssl.conf
 * utf8.conf
 
-These can be included into your site definitions.
+These can be included into your site definitions (See Example playbook below).
 
 ## Example playbook
 


### PR DESCRIPTION
(This change is based on my other nginx wording branch on the assumption that will be accepted).

This change clarifies the wording around the rules files that are copied in and how they are used.

I'm still trying to figure out the redirects: section and ssl: only: (yes|no) options since I don't see it used in the code base so there may be another branch for that in future.
