### PR TITLE
Added quotes to with_items as this is an error with Ansible 2.2

### DIFF
--- a/tasks/manage_confs.yml
+++ b/tasks/manage_confs.yml
@@ -6,7 +6,7 @@
   args:
     creates: "/etc/apache2/conf-enabled/{{ item.id }}.conf"
   when: item.state is not defined or item.state != 'absent'
-  with_items: apache2_confs
+  with_items: "{{ apache2_confs }}"
   notify: reload apache2
 
 - name: Disabling conf
@@ -15,5 +15,5 @@
   args:
     removes: "/etc/apache2/conf-enabled/{{ item.id }}.conf"
   when: item.state is defined and item.state == 'absent'
-  with_items: apache2_confs
+  with_items: "{{ apache2_confs }}"
   notify: reload apache2

--- a/tasks/manage_modules.yml
+++ b/tasks/manage_modules.yml
@@ -6,7 +6,7 @@
   args:
     creates: "/etc/apache2/mods-enabled/{{ item.id }}.load"
   when: item.state is not defined or item.state != 'absent'
-  with_items: apache2_modules
+  with_items: "{{ apache2_modules }} "
   notify: reload apache2
 
 - name: Disabling modules
@@ -15,5 +15,5 @@
   args:
     removes: "/etc/apache2/mods-enabled/{{ item.id }}.load"
   when: item.state is defined and item.state == 'absent'
-  with_items: apache2_modules
+  with_items: "{{ apache2_modules }}"
   notify: reload apache2

--- a/tasks/manage_modules.yml
+++ b/tasks/manage_modules.yml
@@ -6,7 +6,7 @@
   args:
     creates: "/etc/apache2/mods-enabled/{{ item.id }}.load"
   when: item.state is not defined or item.state != 'absent'
-  with_items: "{{ apache2_modules }} "
+  with_items: "{{ apache2_modules }}"
   notify: reload apache2
 
 - name: Disabling modules

--- a/tasks/manage_sites.yml
+++ b/tasks/manage_sites.yml
@@ -5,7 +5,7 @@
     dest: "/var/www/{{ item.id }}/htdocs"
     state: directory
   when: item.add_webroot is defined and item.add_webroot == true
-  with_items: apache2_sites
+  with_items: "{{ apache2_sites }}"
 
 - name: Creating sites
   template:
@@ -14,7 +14,7 @@
     owner: root
     group: root
     mode: "0644"
-  with_items: apache2_sites
+  with_items: "{{ apache2_sites }}"
 
 - name: Enabling sites
   file:
@@ -22,7 +22,7 @@
     dest: "/etc/apache2/sites-enabled/{{ item.id }}.conf"
     state: link
   when: item.state is not defined or item.state == 'present'
-  with_items: apache2_sites
+  with_items: "{{ apache2_sites }}"
   notify: reload apache2
 
 - name: Disabling sites
@@ -30,5 +30,5 @@
     src: "/etc/apache2/sites-enabled/{{ item.id }}.conf"
     state: absent
   when: item.state is defined and item.state == 'absent'
-  with_items: apache2_sites
+  with_items: "{{ apache2_sites }}"
   notify: reload apache2


### PR DESCRIPTION
Hi franklin,

Thanks for this great Ansible role!

When using it with Ansible 2.2 I got the error
```
FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'unicode object' has no attribute 'id'
```
so I changed it to using quotes. It would be great if you could update the role on the Ansible Galaxy.

Thanks, Kay