### PR TITLE
default_site_template: adding the opportunity to generally choose a different site template

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ apache2_certs_path: /etc/ssl/certs
 # path to keys
 apache2_keys_path: /etc/ssl/private
 
+# template to render sites from if no template is configured in apache2_sites...template
+default_site_template: etc/apache2/sites-available/site.j2
+
 ```
 
 ## Handlers

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ apache2_certs_path: /etc/ssl/certs
 apache2_keys_path: /etc/ssl/private
 
 # template to render sites from if no template is configured in apache2_sites...template
-default_site_template: etc/apache2/sites-available/site.j2
+apache2_common_site_template: etc/apache2/sites-available/site.j2
 
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -63,4 +63,4 @@ apache2_certs_path: /etc/ssl/certs
 apache2_keys_path: /etc/ssl/private
 
 # template to render sites from if no template is configured in apache2_sites...template
-default_site_template: etc/apache2/sites-available/site.j2
+apache2_common_site_template: etc/apache2/sites-available/site.j2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,3 +61,6 @@ apache2_trace_enable: 'Off'
 apache2_certs_path: /etc/ssl/certs
 # path to keys
 apache2_keys_path: /etc/ssl/private
+
+# template to render sites from if no template is configured in apache2_sites...template
+default_site_template: etc/apache2/sites-available/site.j2

--- a/tasks/manage_sites.yml
+++ b/tasks/manage_sites.yml
@@ -9,7 +9,7 @@
 
 - name: Creating sites
   template:
-    src: "{{ item.template|default('etc/apache2/sites-available/site.j2') }}"
+    src: "{{ item.template|default(default_site_template) }}"
     dest: "/etc/apache2/sites-available/{{ item.id }}.conf"
     owner: root
     group: root

--- a/tasks/manage_sites.yml
+++ b/tasks/manage_sites.yml
@@ -9,7 +9,7 @@
 
 - name: Creating sites
   template:
-    src: "{{ item.template|default(default_site_template) }}"
+    src: "{{ item.template|default(apache2_common_site_template) }}"
     dest: "/etc/apache2/sites-available/{{ item.id }}.conf"
     owner: root
     group: root


### PR DESCRIPTION
Hi,

I'd like to have the opportunity to put a different site template in for all sites. This would be the change to allow overriding this.

My main interests are not to cruelly reuse the rules folder and the append options and to have different confs included for the https and http vhost. I'd also like to include different confs for different sites, some of them are also provided by packages.

Perhaps the resulting template will be a separate Pull Request later, if I'll be successful in keeping the compatibility to your native template. But at first I'd like to simply override it for all my sites. ;-)

Kind regards,
   Lars