### PR TITLE
apache2_docroot_basedir: Base Directory for Document Roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Here is a list of all the default variables for this role, which are also availa
 # packages (versions)
 apache2_packages:
   - apache2
+# where do we have our document roots (Default /var/www means /var/www/<SiteId>/htdocs)
+apache2_docroot_basedir: /var/www
 # ports to listen to
 apache2_ports: [80]
 # ssl ports to listen to

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,6 +33,8 @@
 # packages (versions)
 apache2_packages:
   - apache2
+# where do we have our document roots (default /var/www means /var/www/<SiteId>/htdocs)
+apache2_docroot_basedir: /var/www
 # ports to listen to
 apache2_ports: [80]
 # ssl ports to listen to

--- a/tasks/manage_sites.yml
+++ b/tasks/manage_sites.yml
@@ -2,7 +2,7 @@
 
 - name: Creating webroots
   file:
-    dest: "/var/www/{{ item.id }}/htdocs"
+    dest: "{{ apache2_docroot_basedir }}/{{ item.id }}/htdocs"
     state: directory
   when: item.add_webroot is defined and item.add_webroot
   with_items: "{{ apache2_sites }}"

--- a/templates/etc/apache2/sites-available/site/body.j2
+++ b/templates/etc/apache2/sites-available/site/body.j2
@@ -1,5 +1,5 @@
   ServerName {{ item.name }}
-  DocumentRoot /var/www/{{ item.id }}/htdocs
+  DocumentRoot {{ apache2_docroot_basedir }}/{{ item.id }}/htdocs
   {% for value in item.aliases|default([]) %}
   ServerAlias {{ value }}
   {% endfor %}
@@ -12,7 +12,7 @@
 
   # --- directories -----------------------------------------------------------
 
-  <Directory /var/www/{{ item.id }}/htdocs>
+  <Directory {{apache2_docroot_basedir}}/{{ item.id }}/htdocs>
     AllowOverride All
     Options FollowSymLinks
     Require all granted

--- a/templates/etc/apache2/sites-available/site/htpasswd.j2
+++ b/templates/etc/apache2/sites-available/site/htpasswd.j2
@@ -1,4 +1,4 @@
-<Directory /var/www/{{ item.id }}/htdocs>
+<Directory {{apache2_docroot_basedir}}/{{ item.id }}/htdocs>
   AuthType Basic
   AuthBasicProvider file
   AuthUserFile /etc/htpasswd/{{ item.auth.file }}


### PR DESCRIPTION
Hi,

this would allow to change the base directory for the document roots of the sites from
/var/www to e.g. /srv/www, if someone wishes to do this.

I left the Default definitions in apache.conf untouched. Because Default allow is IMHO not what is expected by People using e.g. /srv/www and also not necessary with your default site template.

Kind regards
    Lars