### PR TITLE
handlers/main.yml: check apache config before restart

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,11 @@
 ---
 
-- name: restart apache2
+- name: check apache2 config before restart
+  listen: restart apache2
+  command: /usr/sbin/apache2ctl configtest
+
+- name: do restart apache2
+  listen: restart apache2
   service: name=apache2 state=restarted
   when: apache2_service_state != 'stopped'
 


### PR DESCRIPTION
Better run with the old config and throw an configuration check failed error, than don't run.

The path `/usr/sbin/apache2ctl` which is used for the configuration check should be at least suitable for all supported Debian versions and it's derivates, as far as I know.