### PR TITLE
Disable modules before enable.

### DIFF
--- a/tasks/manage_modules.yml
+++ b/tasks/manage_modules.yml
@@ -1,14 +1,5 @@
 ---
 
-- name: Enabling modules
-  command: >
-    a2enmod {{ item.id }}
-  args:
-    creates: "/etc/apache2/mods-enabled/{{ item.id }}.load"
-  when: item.state is not defined or item.state != 'absent'
-  with_items: "{{ apache2_modules }}"
-  notify: test and reload apache2
-
 - name: Disabling modules
   command: >
     a2dismod {{ item.id }}
@@ -17,3 +8,13 @@
   when: item.state is defined and item.state == 'absent'
   with_items: "{{ apache2_modules }}"
   notify: test and reload apache2
+
+- name: Enabling modules
+  command: >
+    a2enmod {{ item.id }}
+  args:
+    creates: "/etc/apache2/mods-enabled/{{ item.id }}.load"
+  when: item.state is not defined or item.state != 'absent'
+  with_items: "{{ apache2_modules }}"
+  notify: test and reload apache2
+  


### PR DESCRIPTION
Disable modules before enable, so that we can switch from mpm_prefork to mpm_event without conflict.