### PR TITLE
feat: allow overriding document_root #15

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@
 # apache2_sites:
 #   - id: mysite (required)
 #     name: mysite.local (required)
+#     document_root: ""
 #     ip: '*'
 #     port: 80
 #     state: present

--- a/templates/etc/apache2/sites-available/site/body.j2
+++ b/templates/etc/apache2/sites-available/site/body.j2
@@ -1,5 +1,9 @@
   ServerName {{ item.name }}
+  {% if item.document_root is defined %}
+  DocumentRoot {{ item.document_root }}
+  {% else %}
   DocumentRoot {{ apache2_sites_basedir }}/{{ item.id }}/htdocs
+  {% endif %}
   {% for value in item.aliases|default([]) %}
   ServerAlias {{ value }}
   {% endfor %}
@@ -12,7 +16,11 @@
 
   # --- directories -----------------------------------------------------------
 
+  {% if item.document_root is defined %}
+  <Directory {{ item.document_root }}>
+  {% else %}
   <Directory {{ apache2_sites_basedir }}/{{ item.id }}/htdocs>
+  {% endif %}
     AllowOverride All
     Options FollowSymLinks
     Require all granted


### PR DESCRIPTION
Implemented the ability to override DocumentRoot. Change is fully backward compatible.

Closes #15